### PR TITLE
last updates in movies controles in res.send genres.

### DIFF
--- a/backend/src/controllers/movies.controllers.ts
+++ b/backend/src/controllers/movies.controllers.ts
@@ -25,7 +25,7 @@ export const getAllmovies = async (
       page: pages / 20 + 1,
       total_pages: moviesCount,
       results: allmovies,
-      genres: allmovies[0].genres,
+      genres: allmovies.length > 0 ? allmovies[0].genres : [],
     });
   } else {
     const moviesCount = await prisma.movie.count({
@@ -59,7 +59,7 @@ export const getAllmovies = async (
       page: pages / 20 + 1,
       total_pages: moviesCount,
       results: movies,
-      genres: movies[0].genres,
+      genres: movies.length > 0 ? movies[0].genres : [],
     });
   }
 };


### PR DESCRIPTION
before the app crash when the pages arrive to a limit of movies pro genres now with the new update the app don’t crash and follow running even is there is not more movies pro genres to show. it can arrive until the limit without crash